### PR TITLE
Fix login redirect bug

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -35,6 +35,20 @@ const Login: React.FC = () => {
   const router = useRouter();
   const loginInitiated = useRef(false);
 
+  // Redirect authenticated users away from the login page
+  useEffect(() => {
+    if (
+      authenticated &&
+      ready &&
+      user &&
+      !loginInitiated.current &&
+      !isLoading &&
+      !isRedirecting
+    ) {
+      router.push('/');
+    }
+  }, [authenticated, ready, user, isLoading, isRedirecting, router]);
+
   const [isLoading, setIsLoading] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);


### PR DESCRIPTION
## Summary
- redirect authenticated users away from /login when visiting the login page

## Testing
- `npm run lint` *(fails: `next` not found)*