### PR TITLE
Fix login redirect bug

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -38,6 +38,21 @@ const Login: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
+
+  // Redirect authenticated users away from the login page
+  useEffect(() => {
+    if (
+      authenticated &&
+      ready &&
+      user &&
+      !loginInitiated.current &&
+      !isLoading &&
+      !isRedirecting
+    ) {
+      router.push('/');
+    }
+  }, [authenticated, ready, user, isLoading, isRedirecting, router]);
+
   const [walletData, setWalletData] = useState<WalletItem[] | null>(
     null
   );


### PR DESCRIPTION
## Summary
- move state declarations above login redirect effect so the code can build

## Testing
- `npm run lint` *(fails: `next` not found)*