### PR TITLE
Update viewer analytics header

### DIFF
--- a/components/analytics/viewer-analytics.tsx
+++ b/components/analytics/viewer-analytics.tsx
@@ -119,7 +119,7 @@ export default function ViewerAnalytics({ viewersData }: any) {
       {/* Viewers List */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-medium">List of Viewers</CardTitle>
+          <CardTitle className="text-lg font-bold underline">List of Viewers</CardTitle>
         </CardHeader>
         <CardContent>
           {viewersData?.length ? (


### PR DESCRIPTION
## Summary
- tweak `List of Viewers` header in analytics page to be bold and underlined

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bba0acfcc832d8d135db91078e134